### PR TITLE
add getting started/installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ changes occur from time to time.
  * Each example or group can have metadata atteched that will be made available
      through the context object. This can be used modify what happens in the
      setup code.
+     
+## Getting Started
+
+Run `npm install --save re-respect` and add `re-respect` to the `bs-dependencies` in `bsconfig.json`.
 
 For more info, see the full [Documentation](https://github.com/PeteProgrammer/respect/blob/master/Documentation.md)
 


### PR DESCRIPTION
This helps with quick lookup. You don't always need the full documentation.

I like to name this section "Installation", but it seemed more fitting to name it "Getting Started", so it flows better into the link to the full documentation.

I won't take offense if you change and move things around, the point is just having the information easily available :)